### PR TITLE
fixed handling of None return from find_library()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,21 +181,25 @@ else:
 # ---------------------------------------------------------------------------------------- 
 if len(libraries) == 0:
     for lib in DEFAULT_LIBRARIES:
-        libpath = os.path.dirname(os.path.realpath(find_library(lib)))
-        if len(libpath) > 0:
+        lib_path = find_library(lib)
+        if isinstance(lib_path, str):
+            lib_dir = os.path.dirname(os.path.realpath(lib_path))
+        else:
+            continue
+        if len(lib_dir) > 0:
             libraries.append(lib)
-            libdirs.append(libpath)
+            libdirs.append(lib_dir)
             if system == 'Linux':
-                incpath = glob.glob(libpath.replace('/lib/x86_64-linux-gnu','/include').replace('/lib64','/include')+\
+                incpath = glob.glob(lib_dir.replace('/lib/x86_64-linux-gnu','/include').replace('/lib64','/include')+\
                           '/**/*'+lib.replace('jp2','jpeg')+'.h',recursive=True)
             else:
                 if lib == 'openjp2':
-                    incpath = glob.glob(libpath.replace('/lib','/include')+'/**/*'+lib.replace('jp2','jpeg')+'.h',recursive=True)
+                    incpath = glob.glob(lib_dir.replace('/lib','/include')+'/**/*'+lib.replace('jp2','jpeg')+'.h',recursive=True)
                 elif lib == 'png':
-                    incpath = glob.glob(libpath.replace('/lib','/include').replace('includepng','libpng')+'/**/*'+lib+'.h',recursive=True)
+                    incpath = glob.glob(lib_dir.replace('/lib','/include').replace('includepng','libpng')+'/**/*'+lib+'.h',recursive=True)
                 else:
-                    incpath = glob.glob(libpath.replace('/lib','/include')+'/**/*'+lib+'.h',recursive=True)
-                print(lib,libpath,incpath)
+                    incpath = glob.glob(lib_dir.replace('/lib','/include')+'/**/*'+lib+'.h',recursive=True)
+                print(lib,lib_dir,incpath)
             if len(incpath) > 0:
                 incdirs.append(os.path.dirname(incpath[0]))
 


### PR DESCRIPTION
Added a check to ensure a path (`str`) was returned from `find_library()`, otherwise, if `None` is returned, the current `lib` was not found, so we continue to the next `lib` in `DEFAULT_LIBRARIES`.