### PR TITLE
Remove `pygrib` dependency for obtaining Gaussian latitudes.

### DIFF
--- a/grib2io/_grib2io.py
+++ b/grib2io/_grib2io.py
@@ -30,6 +30,7 @@ import pyproj
 
 from . import tables
 from . import utils
+from .gauss_grid import gaussian_latitudes
 
 
 DEFAULT_FILL_VALUE = 9.9692099683868690e+36
@@ -1304,10 +1305,6 @@ class Grib2Message:
             self.projparams['proj'] = 'cyl'
             lons,lats = np.meshgrid(lons,lats) # make 2-d arrays.
         elif gdtnum == 40: # gaussian grid (only works for global!)
-            try:
-                from pygrib import gaulats
-            except:
-                raise ImportError("pygrib required to compute Gaussian latitude")
             lon1, lat1 = self.longitudeFirstGridpoint, self.latitudeFirstGridpoint
             lon2, lat2 = self.longitudeLastGridpoint, self.latitudeLastGridpoint
             nlats = self.ny
@@ -1319,7 +1316,7 @@ class Grib2Message:
                 dlon = self.gridlengthXDirection
             lons = np.arange(lon1,lon2+dlon,dlon)
             # Compute gaussian lats (north to south)
-            lats = gaulats(nlats)
+            lats = gaussian_latitudes(int(nlats/2))
             if lat1 < lat2:  # reverse them if necessary
                 lats = lats[::-1]
             # flip if scan mode says to.

--- a/grib2io/gauss_grid.py
+++ b/grib2io/gauss_grid.py
@@ -1,0 +1,62 @@
+"""Tools for working with Gaussian grids."""
+# Adopted from: https://gist.github.com/ajdawson/b64d24dfac618b91974f
+from __future__ import (absolute_import, division, print_function)
+
+import functools
+
+import numpy as np
+import numpy.linalg as la
+from numpy.polynomial.legendre import legcompanion, legder, legval
+
+
+def __single_arg_fast_cache(func):
+    """Caching decorator for functions of one argument."""
+    class CachingDict(dict):
+
+        def __missing__(self, key):
+            result = self[key] = func(key)
+            return result
+
+        @functools.wraps(func)
+        def __getitem__(self, *args, **kwargs):
+            return super(CachingDict, self).__getitem__(*args, **kwargs)
+
+    return CachingDict().__getitem__
+
+
+@__single_arg_fast_cache
+def gaussian_latitudes(n):
+    """Construct latitudes for a Gaussian grid.
+
+    Args:
+
+    * n:
+        The Gaussian grid number (half the number of latitudes in the
+        grid.
+    Returns:
+        A length `n` array of latitudes (in degrees)
+    """
+    if abs(int(n)) != n:
+        raise ValueError('n must be a non-negative integer')
+    nlat = 2 * n
+    # Create the coefficients of the Legendre polynomial and construct the
+    # companion matrix:
+    cs = np.array([0] * nlat + [1], dtype=int)
+    cm = legcompanion(cs)
+    # Compute the eigenvalues of the companion matrix (the roots of the
+    # Legendre polynomial) taking advantage of the fact that the matrix is
+    # symmetric:
+    roots = la.eigvalsh(cm)
+    roots.sort()
+    # Improve the roots by one application of Newton's method, using the
+    # solved root as the initial guess:
+    fx = legval(roots, cs)
+    fpx = legval(roots, legder(cs))
+    roots -= fx / fpx
+    # The roots should exhibit symmetry, but with a sign change, so make sure
+    # this is the case:
+    roots = (roots - roots[::-1]) / 2.
+    # Convert the roots from the interval [-1, 1] to latitude values on the
+    # interval [-90, 90] degrees:
+    latitudes = np.rad2deg(np.arcsin(roots))
+    return latitudes


### PR DESCRIPTION
Hello:

This PR removes the dependency on `pygrib` for obtaining Gaussian latitudes and instead adds a standalone function.
The function is adopted from [here](https://gist.github.com/ajdawson/b64d24dfac618b91974f) and an acknowledgement/credit has been placed in the added file.

Please feel free to suggest moving the contents of `gauss_grid.py` to `utils` or elsewhere as you see fit.

Thank you for your consideration.